### PR TITLE
Fix Vue 3 instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ interface Options {
 ```ts
 // vue3
 import { createApp } from 'vue'
-import VueScan, { type VueScanOptions } from 'z-vue-scan/src'
+import VueScan, { type VueScanOptions } from 'z-vue-scan'
 
 import App from './App.vue'
 


### PR DESCRIPTION
Readme needs updating, otherwise you'd get an import error that `./src` doesn't exist. Saw that in the example in the repo it did correctly import it already.